### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/5tring5/ghana-road-toll-system/security/code-scanning/1](https://github.com/5tring5/ghana-road-toll-system/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow does not perform any write operations to the repository. This change will ensure that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of unintended or malicious actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
